### PR TITLE
Fix format switch usage to work on windows

### DIFF
--- a/index.js
+++ b/index.js
@@ -39,10 +39,10 @@ async function gitLogNumStat(branch) {
   //  --diff-filter=d Don't show deleted files in the output. The --no-renames causes a rename to
   //      be shown as two files. But it's not clear which was added and which was removed. So I
   //      use this diff-filter to remove the deleted file leaving just the added file.
-  //  --format=format:'%h %f' For the commit only print out the abbreviated hash and subject
+  //  --format=oneline --abbrev-commit:For the commit only print out the abbreviated hash and subject
   //      line( the files that changed are still printed as specified earlier)
 
-  const { stdout } = await exec(`git log --numstat --no-renames --diff-filter=d --format=format:'commit %h %f' master..${branch}`);
+  const { stdout } = await exec(`git log --numstat --no-renames --diff-filter=d --format=oneline --abbrev-commit master..${branch}`);
 
   // Output will be something like the following with a trailing blank line for each commit
   // commit 1ff8e4d

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lfs-check",
-  "version": "0.5.0-alpha.1",
+  "version": "0.5.0-alpha.2",
   "description": "Make sure your binary files are tracked with git-lfs not checked into your repo.",
   "main": "./index.js",
   "preferGlobal": true,


### PR DESCRIPTION
Was using a custom format string delimited by single
quotes. This didn't work in Git Bash on windows.
Using double quotes made it work. But instead I just
decided to use built-in switches:

  --format=oneline --abrev-commit

Which does the thing I wanted.

Fixes #24