### PR TITLE
Fix the formatting of commits in output

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,9 +11,12 @@ function processCommitChunk(commitChunk) {
 
   if (lines.length > 1) {
   // first line has the word commmit followed by the hash
-    const [, hash, ...words] = lines[0].split(/\s+/);
+    const splitIndex = lines[0].indexOf(' ');
+    const hash = lines[0].substring(0, splitIndex);
+    const words = lines[0].substring(splitIndex).trim();
+
     commitObject.id = hash;
-    commitObject.message = words.join();
+    commitObject.message = words;
 
     const binaries = lines
       .slice(1)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lfs-check",
-  "version": "0.5.0-alpha.2",
+  "version": "0.5.0-alpha.3",
   "description": "Make sure your binary files are tracked with git-lfs not checked into your repo.",
   "main": "./index.js",
   "preferGlobal": true,


### PR DESCRIPTION
In an earlier commit I removed the work `Commit` from
the output message for a commit. This broke the formatting
parser elsewhere in the program. I've corrected for that
change now.